### PR TITLE
Enhance cuisine selection by allowing custom input in recipe generator

### DIFF
--- a/app.py
+++ b/app.py
@@ -223,13 +223,24 @@ with st.sidebar:
             index=0,
             help="What type of meal are you preparing?"
         )
+        cuisine_options = [
+            "Any", "Italian", "Indian", "Pakistani", "Pakistani (Traditional)", "Mexican", "Chinese", "Mediterranean", "Thai", "Japanese", "French", "American", "Fusion"
+        ]
         cuisine_input_val = st.selectbox(
             "Cuisine Style",
-            [
-                "Any", "Italian", "Indian", "Pakistani", "Pakistani (Traditional)", "Mexican", "Chinese", "Mediterranean", "Thai", "Japanese", "French", "American", "Fusion"
-            ],
-            help="Select a preferred cuisine style, or 'Any' for flexibility."
+            cuisine_options,
+            help="Select a preferred cuisine style, or 'Any' for flexibility. You can also type your own cuisine.",
+            key="cuisine_selectbox"
         )
+        # Allow user to type a custom cuisine
+        custom_cuisine = st.text_input(
+            "Or type your own cuisine style",
+            value="" if cuisine_input_val == "Any" else cuisine_input_val if cuisine_input_val not in cuisine_options else "",
+            key="custom_cuisine_input",
+            help="Type any cuisine style not listed above. This will override the selection above if filled."
+        )
+        if custom_cuisine.strip():
+            cuisine_input_val = custom_cuisine.strip()
         diet_input_val = st.selectbox(
             "Dietary Preference",
             ["None", "Vegetarian", "Vegan", "Gluten-Free", "Keto", "Paleo", "Dairy-Free", "Low-Carb", "Pescatarian"],


### PR DESCRIPTION
This feature enhances the "Cuisine Style" input in the recipe preferences sidebar of the Streamlit AI Recipe Generator app. In addition to selecting from a predefined list of popular cuisines, users can now type in any cuisine of their choice using a dedicated text input field. If a custom cuisine is entered, it will override the dropdown selection, allowing for greater flexibility and personalization in recipe generation. This ensures users are not limited to preset options and can request recipes for any cuisine style they desire.